### PR TITLE
Add TAP aggregate permissions

### DIFF
--- a/config/rbac/aggregated_roles.yaml
+++ b/config/rbac/aggregated_roles.yaml
@@ -2,6 +2,45 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: app-viewer
+  labels:
+    # Add these permissions to the "app-viewer" role.
+    apps.tanzu.vmware.com/aggregate-to-app-viewer: "true"
+rules:
+- apiGroups: ["conventions.carto.run"]
+  resources: ["podintents"]
+  verbs: ["get","list","watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: app-viewer-cluster-access
+  labels:
+    # Add these permissions to the "app-viewer-cluster-access" role.
+    apps.tanzu.vmware.com/aggregate-to-app-viewer-cluster-access: "true"
+rules:
+- apiGroups: ["conventions.carto.run"]
+  resources: ["clusterpodconventions"]
+  verbs: ["get","list","watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: app-operator-cluster-access
+  labels:
+    # Add these permissions to the "app-operator-cluster-access" role.
+    apps.tanzu.vmware.com/aggregate-to-app-operator-cluster-access: "true"
+rules:
+- apiGroups: ["conventions.carto.run"]
+  resources: ["clusterpodconventions"]
+  verbs: ["get","list","watch","create","patch","update","delete","deletecollection"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: role
   labels:
     # Add these permissions to the "edit" default role.

--- a/dist/cartogrpaher-conventions.yaml
+++ b/dist/cartogrpaher-conventions.yaml
@@ -6375,6 +6375,62 @@ rules:
   verbs:
   - create
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    apps.tanzu.vmware.com/aggregate-to-app-operator-cluster-access: "true"
+    component: conventions.carto.run
+  name: cartographer-conventions-app-operator-cluster-access
+rules:
+- apiGroups:
+  - conventions.carto.run
+  resources:
+  - clusterpodconventions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+  - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    apps.tanzu.vmware.com/aggregate-to-app-viewer: "true"
+    component: conventions.carto.run
+  name: cartographer-conventions-app-viewer
+rules:
+- apiGroups:
+  - conventions.carto.run
+  resources:
+  - podintents
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    apps.tanzu.vmware.com/aggregate-to-app-viewer-cluster-access: "true"
+    component: conventions.carto.run
+  name: cartographer-conventions-app-viewer-cluster-access
+rules:
+- apiGroups:
+  - conventions.carto.run
+  resources:
+  - clusterpodconventions
+  verbs:
+  - get
+  - list
+  - watch
+---
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:


### PR DESCRIPTION
Define ClusterRoles that contribute permissions to commonly defined
ClusterRoles within TAP. These ClusterRoles do nothing until bound to a
user/group/serviceaccount with a (Cluster)RoleBinding. The names of
these ClusterRoles should not be relied upon. Only the aggregated role
is supported, which is not defined by this component).

Signed-off-by: Scott Andrews <andrewssc@vmware.com>
