### PR TITLE
Avoid kapp phantom diff on AKS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ manifests:
 dist: dist/cartogrpaher-conventions.yaml
 
 dist/cartogrpaher-conventions.yaml: generate manifests
-	$(KUSTOMIZE) build config/default | $(YTT) -f - -f dist/strip-status.yaml > dist/cartogrpaher-conventions.yaml
+	$(KUSTOMIZE) build config/default \
+	  | $(YTT) -f - -f dist/strip-status.yaml -f dist/aks-webhooks.yaml \
+	  > dist/cartogrpaher-conventions.yaml
 
 dist/third-party: dist/third-party/cert-manager.yaml
 

--- a/dist/aks-webhooks.yaml
+++ b/dist/aks-webhooks.yaml
@@ -1,0 +1,26 @@
+#! Copyright 2022 VMware Inc.
+#!
+#! Licensed under the Apache License, Version 2.0 (the "License");
+#! you may not use this file except in compliance with the License.
+#! You may obtain a copy of the License at
+#!
+#!     http://www.apache.org/licenses/LICENSE-2.0
+#!
+#! Unless required by applicable law or agreed to in writing, software
+#! distributed under the License is distributed on an "AS IS" BASIS,
+#! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#! See the License for the specific language governing permissions and
+#! limitations under the License.
+
+#@ load("@ytt:overlay", "overlay")
+
+#@ mutating_webhook = overlay.subset({"apiVersion": "admissionregistration.k8s.io/v1", "kind": "MutatingWebhookConfiguration"})
+#@ validating_webhook = overlay.subset({"apiVersion": "admissionregistration.k8s.io/v1", "kind": "ValidatingWebhookConfiguration"})
+
+#@overlay/match by=overlay.or_op(mutating_webhook,validating_webhook), expects="0+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    admissions.enforcer/disabled: "true"

--- a/dist/cartogrpaher-conventions.yaml
+++ b/dist/cartogrpaher-conventions.yaml
@@ -6853,6 +6853,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: cartographer-conventions-system/cartographer-conventions-serving-cert
+    admissions.enforcer/disabled: "true"
   labels:
     component: conventions.carto.run
   name: cartographer-conventions-mutating-webhook-configuration
@@ -6903,6 +6904,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: cartographer-conventions-system/cartographer-conventions-serving-cert
+    admissions.enforcer/disabled: "true"
   labels:
     component: conventions.carto.run
   name: cartographer-conventions-validating-webhook-configuration


### PR DESCRIPTION
AKS injects an additional facet into the namespaceSelector for mutating
and validating webhook configurations. The next time kapp deploys the
dist, it removes the injected values as drift, and so on in a loop.

We can disable the AKS behavior by specifying an annotation
`admissions.enforcer/disabled: "true"`. This makes the webhooks behave
like on other k8s distributions.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>
