### PR TITLE
Bump kind to 0.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,9 +201,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-        - 1.21.2
-        - 1.22.4
-        - 1.23.1
+        - 1.21.10
+        - 1.22.7
+        - 1.23.4
     env:
       REGISTRY_NAME: registry.local
       BUNDLE: registry.local/conventions/bundle
@@ -216,7 +216,7 @@ jobs:
     - name: Install kind
       run: |
         cd $(mktemp -d -t kind.XXXX)
-        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-$(go env GOHOSTOS)-$(go env GOHOSTARCH)
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.12.0/kind-$(go env GOHOSTOS)-$(go env GOHOSTARCH)
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin
         cd -


### PR DESCRIPTION
Also update node images to the latest patch version within the
respective minor version.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>
