### PR TITLE
Drop ca.pem from bundle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,6 @@ jobs:
         cp dist/bundle.yaml "${scratch}/bundle.yaml"
         cp dist/bundle.values.yaml "${scratch}/bundle.values.yaml"
         cp dist/ca-overlay.yaml "${scratch}/ca-overlay.yaml"
-        cp dist/ca.pem "${scratch}/ca.pem"
 
         echo "##[group]Build"
           cat hack/boilerplate.ytt.txt > "${scratch}/config/cartographer-conventions.yaml"


### PR DESCRIPTION
The file was unused. The ca.pem file is only used as a default when
building from source following the readme's instructions. Users can
still provide additional CAs via the PackageInstall values.

Follow up to https://github.com/vmware-tanzu/cartographer-conventions/pull/51#discussion_r832596120

Signed-off-by: Scott Andrews <andrewssc@vmware.com>
