### PR TITLE
Only release semver tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,8 @@ on:
     - 'main'
     - '!dependabot/**'
     tags:
-    - '**'
+    # semver tags
+    - 'v[0-9]+.[0-9]+.[0-9]+-?**'
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
We need to create multiple tags for the same commit so that go can
resolve the webhook module. We don't need to run CI on those tags.

Otherwise we'll get an error from the release script like
https://github.com/vmware-tanzu/cartographer-conventions/runs/5684344434?check_suite_focus=true

Signed-off-by: Scott Andrews <andrewssc@vmware.com>
