### PR TITLE
Skip containers with no image metadata

### DIFF
--- a/samples/spring-convention-server/server.go
+++ b/samples/spring-convention-server/server.go
@@ -44,7 +44,8 @@ func addSpringBootConventions(template *corev1.PodTemplateSpec, images []webhook
 		container := &template.Spec.Containers[i]
 		image, ok := imageMap[container.Image]
 		if !ok {
-			return nil, fmt.Errorf("missing image metadata for %q", container.Image)
+			// skip containers without metadata, this may be a container without an image
+			continue
 		}
 		dependencyMetadata := resources.NewDependenciesBOM(image.BOMs)
 		applicationProperties := resources.SpringApplicationProperties{}


### PR DESCRIPTION
Conventions should be lenient in how the handle inputs. The example
Spring Boot convention returned an error if there was no metadata for
an image. This can happen if there is no image for a container. The
sample now skips processing of containers that don't have image
metadata.

Resolves #76 