### PR TITLE
Accommodate  metadata.clusterName changes to allow v0.24.0 upgrade

### DIFF
--- a/pkg/apis/conventions/v1alpha1/podtemplatespec.go
+++ b/pkg/apis/conventions/v1alpha1/podtemplatespec.go
@@ -151,6 +151,12 @@ func (m *ObjectMeta) GetClusterName() string {
 func (m *ObjectMeta) SetClusterName(clusterName string) {
 	panic(fmt.Errorf("SetClusterName is not implemented"))
 }
+func (m *ObjectMeta) GetZZZDeprecatedClusterName() string {
+	panic(fmt.Errorf("GetZZZDeprecatedClusterName is not implemented"))
+}
+func (m *ObjectMeta) SetZZZDeprecatedClusterName(clusterName string) {
+	panic(fmt.Errorf("SetZZZDeprecatedClusterName is not implemented"))
+}
 func (m *ObjectMeta) GetManagedFields() []metav1.ManagedFieldsEntry {
 	panic(fmt.Errorf("GetManagedFields is not implemented"))
 }

--- a/pkg/apis/conventions/v1alpha1/podtemplatespec.go
+++ b/pkg/apis/conventions/v1alpha1/podtemplatespec.go
@@ -145,12 +145,6 @@ func (m *ObjectMeta) GetOwnerReferences() []metav1.OwnerReference {
 func (m *ObjectMeta) SetOwnerReferences([]metav1.OwnerReference) {
 	panic(fmt.Errorf("SetOwnerReferences is not implemented"))
 }
-func (m *ObjectMeta) GetClusterName() string {
-	panic(fmt.Errorf("GetClusterName is not implemented"))
-}
-func (m *ObjectMeta) SetClusterName(clusterName string) {
-	panic(fmt.Errorf("SetClusterName is not implemented"))
-}
 func (m *ObjectMeta) GetZZZDeprecatedClusterName() string {
 	panic(fmt.Errorf("GetZZZDeprecatedClusterName is not implemented"))
 }


### PR DESCRIPTION

Would like to apply the name changes associated with the upstream `metadata.Clustername` updates in [1.24 release](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#changes-by-kind) in our [podTemplateSpec](https://github.com/vmware-tanzu/cartographer-conventions/blob/e9e3abab4d828d96a3f2211f45b7d7fe223e7399/pkg/apis/conventions/v1alpha1/podtemplatespec.go#L148) with the intention of allowing the upgrade to be kicked off by the open upgrade PRs.

Allow the bot upgrades to be picked up successfully as they expect us to reference the renamed functions added on this PR. The fields have not been entirely  removed in this release.