### PR TITLE
chore: use updatecli to keep the base image up to date

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,23 @@
+name: Update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "5 * * * *"
+
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+jobs:
+
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install UpdateCLI
+      uses: updatecli/updatecli-action@v2
+
+    - name: Run UpdateCLI
+      run: "updatecli apply --push=false"

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -2,6 +2,7 @@ name: Update
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron: "5 * * * *"
 
@@ -20,4 +21,19 @@ jobs:
       uses: updatecli/updatecli-action@v2
 
     - name: Run UpdateCLI
-      run: "updatecli apply --push=false"
+      id: updatecli
+      run: |
+        output=$(updatecli apply --push=false)
+        echo $output
+        output="${output//$'\n'/\\n}"
+        
+        echo "stdout=$output" >> $GITHUB_OUTPUT
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      if: github.event_name != 'pull_request'
+      with:
+        commit-message: 'chore: bumped base image digest'
+        signoff: false
+        title: 'chore: bumped base image digest'
+        body: ${{ steps.updatecli.outputs.stdout }} 

--- a/updatecli.d/ko.yaml
+++ b/updatecli.d/ko.yaml
@@ -1,0 +1,19 @@
+name: Update baseImage in .ko.yaml
+
+sources:
+  lastDockerDigest:
+    kind: dockerdigest
+    spec:
+      image: "paketobuildpacks/run-jammy-tiny"
+      tag: "latest"
+
+# Defines "targets" which need to be updated if different than "source" information.
+targets:
+  dataFile:
+    name: Bump Docker Image Tag
+    kind: yaml
+    transformers:
+      - addprefix: paketobuildpacks/run-jammy-tiny@ 
+    spec:
+      key: defaultBaseImage
+      file: .ko.yaml


### PR DESCRIPTION
### What this PR does / why we need it

This tool introduces a tool called [updatecli](https://www.updatecli.io/) that can be used to automatically bump an image digest inside a `.ko.yaml` file.  This will allow us to produce repeatable builds

The cron is set to trigger every hour (or on demand)

You can test this locally with:

```
act workflow_dispatch -j update
```
