### PR TITLE
update ci to include tests for v0.27.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,12 +199,12 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
-        - 1.21.10
         - 1.22.7
         - 1.23.4
         - 1.24.2
         - 1.25.0
         - 1.26.0
+        - 1.27.2
     env:
       REGISTRY_NAME: registry.local
       BUNDLE: registry.local/conventions/bundle
@@ -219,7 +219,7 @@ jobs:
     - name: Install kind
       run: |
         cd $(mktemp -d -t kind.XXXX)
-        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-$(go env GOHOSTOS)-$(go env GOHOSTARCH)
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.19.0/kind-$(go env GOHOSTOS)-$(go env GOHOSTARCH)
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin
         cd -


### PR DESCRIPTION
Update kind version to v0.19.0 and add 1.27.x to the test matrix.