### PR TITLE
Draft: Add change rule to install after Cartographer

### DIFF
--- a/dist/package-install.yaml
+++ b/dist/package-install.yaml
@@ -25,6 +25,7 @@ metadata:
   annotations:
     kapp.k14s.io/change-group: conventions.carto.run/install
     kapp.k14s.io/change-rule: "upsert after upserting conventions.carto.run/install-rbac"
+    kapp.k14s.io/change-rule.cartographer: "upsert after upserting cartographer"
 spec:
   serviceAccountName: #@ data.values.service_account_name
   syncPeriod: #@ data.values.sync_period


### PR DESCRIPTION
Pull request

### What this PR does / why we need it

This change rule is intended to fix a race condition that occurs during an upgrade install from the old bundle that contained both Cartographer and Cartographer Conventions.  Sometimes the new Cartographer Conventions package would try to apply resources to the cluster before the updated Cartographer package would relinquish control of them.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
