### PR TITLE
chore: bumped base image digest

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: paketobuildpacks/run-jammy-tiny@sha256:2d87eb82a91fda704539eb12ffd9b178c44e05a937dad947faabb1341173602b
+defaultBaseImage: paketobuildpacks/run-jammy-tiny@sha256:0c5ac79d549c4b077a7d857631f817f8b573f5da2c109a51f320ee584d44d3f2


### PR DESCRIPTION
\n\n+++++++++++\n+ PREPARE +\n+++++++++++\n\nLoading Pipeline "updatecli.d/ko.yaml"\n\nSCM repository retrieved: 0\n\n\n++++++++++++++++++\n+ AUTO DISCOVERY +\n++++++++++++++++++\n\n\n\n++++++++++++\n+ PIPELINE +\n++++++++++++\n\n\n\n################################\n# UPDATE BASEIMAGE IN .KO.YAML #\n################################\n\nsource: source#lastDockerDigest\n-----------------------\n✔ Docker Image Tag paketobuildpacks/run-jammy-tiny:latest resolved to digest index.docker.io/paketobuildpacks/run-jammy-tiny@sha256:0c5ac79d549c4b077a7d857631f817f8b573f5da2c109a51f320ee584d44d3f2\n\ntarget: target#dataFile\n---------------\n[transformers]\n✔ Result correctly transformed from "@sha256:0c5ac79d549c4b077a7d857631f817f8b573f5da2c109a51f320ee584d44d3f2" to "paketobuildpacks/run-jammy-tiny@sha256:0c5ac79d549c4b077a7d857631f817f8b573f5da2c109a51f320ee584d44d3f2"\n⚠ - change detected:\n	* key "$.defaultBaseImage" updated from "paketobuildpacks/run-jammy-tiny@sha256:2d87eb82a91fda704539eb12ffd9b178c44e05a937dad947faabb1341173602b" to "paketobuildpacks/run-jammy-tiny@sha256:0c5ac79d549c4b077a7d857631f817f8b573f5da2c109a51f320ee584d44d3f2", in file ".ko.yaml"\n\n\nACTIONS\n========\n\n\n=============================\n\nSUMMARY:\n\n\n\n⚠ Update baseImage in .ko.yaml:\n	Source:\n		✔ [lastDockerDigest] \n	Target:\n		⚠ [dataFile] Bump Docker Image Tag\n\n\nRun Summary\n===========\nPipeline(s) run:\n  * Changed:	1\n  * Failed:	0\n  * Skipped:	0\n  * Succeeded:	0\n  * Total:	1