### PR TITLE
chore: bumped base image digest

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: paketobuildpacks/run-jammy-tiny@sha256:0c5ac79d549c4b077a7d857631f817f8b573f5da2c109a51f320ee584d44d3f2
+defaultBaseImage: paketobuildpacks/run-jammy-tiny@sha256:d600c7f29a06aa60c8134b0a9f135148b23b6e1b880b9512f81470c00954248c


### PR DESCRIPTION
\n\n+++++++++++\n+ PREPARE +\n+++++++++++\n\nLoading Pipeline "updatecli.d/ko.yaml"\n\nSCM repository retrieved: 0\n\n\n++++++++++++++++++\n+ AUTO DISCOVERY +\n++++++++++++++++++\n\n\n\n++++++++++++\n+ PIPELINE +\n++++++++++++\n\n\n\n################################\n# UPDATE BASEIMAGE IN .KO.YAML #\n################################\n\nsource: source#lastDockerDigest\n-----------------------\n✔ Docker Image Tag paketobuildpacks/run-jammy-tiny:latest resolved to digest index.docker.io/paketobuildpacks/run-jammy-tiny@sha256:d600c7f29a06aa60c8134b0a9f135148b23b6e1b880b9512f81470c00954248c\n\ntarget: target#dataFile\n---------------\n[transformers]\n✔ Result correctly transformed from "@sha256:d600c7f29a06aa60c8134b0a9f135148b23b6e1b880b9512f81470c00954248c" to "paketobuildpacks/run-jammy-tiny@sha256:d600c7f29a06aa60c8134b0a9f135148b23b6e1b880b9512f81470c00954248c"\n⚠ - change detected:\n	* key "$.defaultBaseImage" updated from "paketobuildpacks/run-jammy-tiny@sha256:0c5ac79d549c4b077a7d857631f817f8b573f5da2c109a51f320ee584d44d3f2" to "paketobuildpacks/run-jammy-tiny@sha256:d600c7f29a06aa60c8134b0a9f135148b23b6e1b880b9512f81470c00954248c", in file ".ko.yaml"\n\n\nACTIONS\n========\n\n\n=============================\n\nSUMMARY:\n\n\n\n⚠ Update baseImage in .ko.yaml:\n	Source:\n		✔ [lastDockerDigest] \n	Target:\n		⚠ [dataFile] Bump Docker Image Tag\n\n\nRun Summary\n===========\nPipeline(s) run:\n  * Changed:	1\n  * Failed:	0\n  * Skipped:	0\n  * Succeeded:	0\n  * Total:	1